### PR TITLE
Docs fixes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
 # Authors
 
-David Kelly - [https://orcid.org/0000-0002-5368-6769] (Main author, code, tests, documentation)
+David Kelly - [https://orcid.org/0000-0002-5368-6769] (Main author, code, tests, documentation)  
 Ilaria Pia la Torre - [https://orcid.org/0009-0006-2733-5283] (Code)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Evaluation and feedback on what works and what does not is always interesting an
 
 To set up `DiscreteEntropy.jl` for local development:
 
-1. Fork `DiscreteEntropy.jl <https://github.com/kellino/DiscreteEntropy.jl>`
+1. Fork [`DiscreteEntropy.jl`](https://github.com/kellino/DiscreteEntropy.jl)
 
 2. Clone your fork locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ To set up `DiscreteEntropy.jl` for local development:
 
 3. Create a branch for local development::
 
+   ```
    git checkout -b name-of-your-bugfix-or-feature
+   ```
 
    Now you can make your changes locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ To set up `DiscreteEntropy.jl` for local development:
 
 2. Clone your fork locally:
 
-   gh repo clone YOURNAME/DiscreteEntropy.jl
+   ```
+   git clone git@github.com:<YOUR ACCOUNT NAME>/DiscreteEntropy.jl.git
+   ```
 
 3. Create a branch for local development::
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,27 +16,31 @@ DiscreteEntropy implements a large collection of entropy estimators.
 
 At present, we have implementations for:
 
-- [`maximum_likelihood`](@ref) MaximumLikelihood
-- [`jackknife_mle`](@ref) JackknifeMLE
-- [`miller_madow`](@ref) MillerMadow
-- [`grassberger`](@ref) Grassberger
-- [`schurmann`](@ref) Schurmann
-- [`schurmann_generalised`](@ref) SchurmannGeneralised
-- [`bub`](@ref) BUB
-- [`chao_shen`](@ref) ChaoShen
-- [`zhang`](@ref) Zhang
-- [`bonachela`](@ref) Bonachela
-- [`shrink`](@ref) Shrink
-- [`chao_wang_jost`](@ref) ChaoWangJost
-- [`unseen`](@ref) Unseen
-- [`bayes`](@ref) Bayes
-- [`jeffrey`](@ref) Jeffrey
-- [`laplace`](@ref) Laplace
-- [`schurmann_grassberger`](@ref) SchurmannGrassberger
-- [`minimax`](@ref) Minimax
-- [`nsb`](@ref) NSB
-- [`ansb`](@ref) ANSB
-- [`pym`](@ref) PYM
+|Function                       |Type                  |
+|-------------------------------|----------------------|
+|[`maximum_likelihood`](@ref)   | MaximumLikelihood    |
+|[`jackknife_mle`](@ref)        | JackknifeMLE         |
+|[`miller_madow`](@ref)         | MillerMadow          |
+|[`grassberger`](@ref)          | Grassberger          |
+|[`schurmann`](@ref)            | Schurmann            |
+|[`schurmann_generalised`](@ref)| SchurmannGeneralised |
+|[`bub`](@ref)                  | BUB                  |
+|[`chao_shen`](@ref)            | ChaoShen             |
+|[`zhang`](@ref)                | Zhang                |
+|[`bonachela`](@ref)            | Bonachela            |
+|[`shrink`](@ref)               | Shrink               |
+|[`chao_wang_jost`](@ref)       | ChaoWangJost         |
+|[`unseen`](@ref)               | Unseen               |
+|[`bayes`](@ref)                | Bayes                |
+|[`jeffrey`](@ref)              | Jeffrey              |
+|[`laplace`](@ref)              | Laplace              |
+|[`schurmann_grassberger`](@ref)| SchurmannGrassberger |
+|[`minimax`](@ref)              | Minimax              |
+|[`nsb`](@ref)                  | NSB                  |
+|[`ansb`](@ref)                 | ANSB                 |
+|[`pym`](@ref)                  | PYM                  |
+
+The type is mainly used with the function [`estimate_h`](@ref), see below.
 
 We also have some non-traditional mixed estimators, such as [`jackknife`](@ref), which allows jackknife
 resampling to be applied to any estimator, [`bayesian_bootstrap`](@ref)

--- a/src/Core/countdata.jl
+++ b/src/Core/countdata.jl
@@ -24,9 +24,9 @@ struct Samples <: EntropyData end
     CountData
 
 # Fields
-- multiplicities::Matrix{Float64}  : multiplicity representation of data
-- N::Float64 : total number of samples
-- K::Int64   : observed support size
+- `multiplicities::Matrix{Float64}`: multiplicity representation of data
+- `N::Float64`: total number of samples
+- `K::Int64`: observed support size
 
 
 # Multiplicities
@@ -201,7 +201,7 @@ end
 
 @doc raw"""
     from_csv(file::String, field, ::Type{T}; remove_zeros=false, header=nothing, kw...) where {T<:EntropyData}
-Simple wrapper around *CSV.File() which returns a [`CountData`](@ref) object. For more complex
+Simple wrapper around `CSV.File()` which returns a [`CountData`](@ref) object. For more complex
 requirements, it is best to call CSV directly.
 """
 function from_csv(file::Union{String,IOBuffer}, field, t::Type{T}; remove_zeros=false, header=false, kw...) where {T<:EntropyData}

--- a/src/Core/countvectors.jl
+++ b/src/Core/countvectors.jl
@@ -2,7 +2,7 @@ using Base: @propagate_inbounds
 
 # using Core: throw_inexacterror
 @doc raw"""
-AbstractCounts{T<:Real,V<:AbstractVector{T}} <: AbstractVector{T}
+    AbstractCounts{T<:Real,V<:AbstractVector{T}} <: AbstractVector{T}
 
 Enforced type incompatibility between vectors of samples, vectors of counts, and
 vectors of xi.

--- a/src/Estimators/Frequentist/bub.jl
+++ b/src/Estimators/Frequentist/bub.jl
@@ -8,8 +8,8 @@ using LinearAlgebra: I, dot, diagm
 
 Compute The Best Upper Bound (BUB) estimation of Shannon entropy, where
 
-`k_max` is a degree of freedom parameter. Paninski states that k_max ~ 10 is optimal for most applications.
-`lambda_0` is the Lagrange multiplier on a_0 (see paper for details). This can be safely left at 0 for most appllications.
+`k_max` is a degree of freedom parameter. Paninski states that `k_max` ~ 10 is optimal for most applications.
+`lambda_0` is the Lagrange multiplier on $a_0$ (see paper for details). This can be safely left at 0 for most applications.
 `truncate` reduces the number of significant digits in intermediate floating point calculates. This exists to bring the output of this function closer to the original Matlab implementation. Leaving it at `false` usually results in a slightly higher entropy estimate.
 
 # Example
@@ -19,7 +19,7 @@ n = [1,2,3,4,5,4,3,2,1]
 (h, MM) = bub(from_counts(n))
 (2.475817360451392, 0.6542542616181388)
 ```
-where h is the estimation of Shannon entropy in `nats` and MM is the upper bound on rms error
+where `h` is the estimation of Shannon entropy in `nats` and `MM` is the upper bound on rms error
 
 # External Links
 [Estimation of Entropy and Mutual Information](https://www.stat.berkeley.edu/~binyu/summer08/L2P2.pdf)

--- a/src/Estimators/Frequentist/frequentist.jl
+++ b/src/Estimators/Frequentist/frequentist.jl
@@ -32,7 +32,7 @@ end
 Compute the *jackknifed* [`maximum_likelihood`](@ref) estimate of data and the variance of the
 jackknifing (not the variance of the estimator itself).
 
-If `corrected` is true, then the variance is scaled with $data.N-1$, else it is scaled with $data.N$. `corrected`
+If `corrected` is true, then the variance is scaled with `data.N - 1`, else it is scaled with `data.N`. `corrected`
 has no effect on the entropy estimation.
 
 # External Links

--- a/src/Estimators/Frequentist/unseen.jl
+++ b/src/Estimators/Frequentist/unseen.jl
@@ -18,17 +18,17 @@ function linprog(c, A, b, Aeq, beq, lb, ub)
 end
 
 @doc raw"""
-  unseen(data::CountData)
+    unseen(data::CountData)
 
 Compute the Unseen estimatation of Shannon entropy.
 
 # Example
 
-``@jldoctest
+```@jldoctest
 n = [1,2,3,4,5,4,3,2,1]
 h = unseen(from_counts(n))
 1.4748194918254784
-``
+```
 
 # External Links
 [Estimating the Unseen: Improved Estimators for Entropy and Other Properties](https://theory.stanford.edu/~valiant/papers/unseenJournal.pdf)

--- a/src/Estimators/estimate.jl
+++ b/src/Estimators/estimate.jl
@@ -81,10 +81,10 @@ julia> estimate_h(from_data(X, Samples), Schurmann)
 ```
 
 ## Note
-While most calls to estimate_h take a CountData struct, this is not true for every estimator.
+While most calls to `estimate_h` take a `CountData` struct, this is not true for every estimator.
 In particular `schurmann_generalised` has a different method call
 
-  estimate_h(data::CountVector, ::Type{SchurmannGeneralised}, xis::XiVector)
+    estimate_h(data::CountVector, ::Type{SchurmannGeneralised}, xis::XiVector)
 
 as this works directly over this sample histogram.
 

--- a/src/Estimators/resample.jl
+++ b/src/Estimators/resample.jl
@@ -67,7 +67,7 @@ end
 
 Compute the jackknifed estimate of `estimator` on `data`.
 
-If `corrected` is true, then the variance is scaled with $data.N-1$, else it is scaled with $data.N$. `corrected`
+If `corrected` is true, then the variance is scaled with `data.N - 1`, else it is scaled with `data.N`. `corrected`
 has no effect on the entropy estimation.
 """
 function jackknife(data::CountData, estimator::Type{T}; corrected=false) where {T<:AbstractEstimator}

--- a/src/InfoTheory/divergence.jl
+++ b/src/InfoTheory/divergence.jl
@@ -100,9 +100,9 @@ end
 
 
 @doc raw"""
-    jensen_shannon_divergence(countsP::CountVector, countsQ::AbstractVector)
-    jensen_shannon_divergence(countsP::CountVector, countsQ::AbstractVector, estimator::Type{T}) where {T<:NonParamterisedEstimator}
-    jensen_shannon_divergence(countsP::CountVector, countsQ::AbstractVector, estimator::Type{Bayes}, α)
+    jensen_shannon_divergence(countsP::CountVector, countsQ::CountVector)
+    jensen_shannon_divergence(countsP::CountVector, countsQ::CountVector, estimator::Type{T}) where {T<:NonParamterisedEstimator}
+    jensen_shannon_divergence(countsP::CountVector, countsQ::CountVector, estimator::Type{Bayes}, α)
 
 Compute the Jensen Shannon Divergence between discrete distributions $P$ and $Q$, as represented by
 their histograms. If no estimator is specified, it defaults to MaximumLikelihood.
@@ -120,7 +120,7 @@ function jensen_shannon_divergence(P::CountVector, Q::CountVector)
 end
 
 @doc raw"""
-    jensen_shannon_distance(P::AbstractVector, Q::AbstractVector, estimator::Type{T}) where T<:AbstractEstimator
+    jensen_shannon_distance(P::CountVector, Q::CountVector, estimator::Type{T}) where {T<:AbstractEstimator}
 
 Compute the Jensen Shannon Distance
 

--- a/src/InfoTheory/divergence.jl
+++ b/src/InfoTheory/divergence.jl
@@ -70,9 +70,9 @@ Compute the [Kullback-Lebler Divergence](https://en.wikipedia.org/wiki/Kullback%
 between two discrete distributions. ``P`` and ``Q`` must be the same length.
 If the distributions are not normalised, they will be.
 
-If the distributions are not over the same space or the cross entropy is negative, then it returns ``Inf``.
+If the distributions are not over the same space or the cross entropy is negative, then it returns `Inf`.
 
-If truncate is set to some integer value, ```x```, return kl_divergence rounded to ```x``` decimal places.
+If truncate is set to some integer value, `x`, return kl_divergence rounded to `x` decimal places.
 """
 function kl_divergence(P::CountVector, Q::CountVector, estimator::Type{T}; truncate::Union{Nothing,Int}=nothing, α=0.0) where {T<:AbstractEstimator}
   if estimator == Bayes


### PR DESCRIPTION
Hi @kellino

another (and I think the last) one with respect to https://github.com/openjournals/joss-reviews/issues/7334

These are my final suggestions for the docs. I thought a PR would not be much more work on my side (maybe even less), so here we go. I tried to make small commits to make the diffs/commit messages clearer.

There are a few places in the doc where the rendering fails because of

- not enough spaces in doc strings in front of code examples (only function definitions, I think; you need four spaces to make it parse as code)
- use of underscore `_` in the docstrings _without_ wrapping the word in backticks, e.g. if you write `estimate_h` without the backticks, the markdown parser will think the underscore should mean whatever comes next should be rendered in italics, and then it completely fails

What I did not touch but where you should have a look:

The `Project.toml`/`Manifest.toml` in `docs` does not include `DiscreteEntropy.jl` itself. So when I ran this environment to build the docs, I first had to do a

```julia
] dev ..
```

to dev the package in the parent directory. Then it works.
Maybe this should be documented somehow.
I did not want to commit my modified Manifest, because it also includes a different julia version (1.10.5) and I am not so sure about including the Manifest anyway.